### PR TITLE
Lower Lombock Version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,10 +15,10 @@ def runeLiteVersion = '1.8.32'
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion
 
-	compileOnly 'org.projectlombok:lombok:1.18.24'
+	compileOnly 'org.projectlombok:lombok:1.18.20'
 	annotationProcessor 'org.projectlombok:lombok:1.18.20'
 
-	testImplementation 'junit:junit:4.13'
+	testImplementation 'junit:junit:4.12'
 	testImplementation group: 'net.runelite', name:'client', version: runeLiteVersion
 	testImplementation group: 'net.runelite', name:'jshell', version: runeLiteVersion
 }

--- a/src/main/java/com/sac/SalveAmuletCheckerConfig.java
+++ b/src/main/java/com/sac/SalveAmuletCheckerConfig.java
@@ -63,7 +63,7 @@ public interface SalveAmuletCheckerConfig extends Config {
     @ConfigItem(
             keyName = "isSidePanelVisible",
             name = "Toggle Side Panel",
-            description = "When disabled the Side Panel Button will be removed.  Requires Runelite restart",
+            description = "When disabled the Side Panel Button will be removed.",
             position = 3
     )
     default boolean isSidePanelVisible() {


### PR DESCRIPTION
Removed verbiage on Restart Required on isSidePanelVisible.  Also lowered the lombok version from 1.18.24 to 1.18.20
